### PR TITLE
BPR-160: update transform method

### DIFF
--- a/Service/MLService.py
+++ b/Service/MLService.py
@@ -2,8 +2,8 @@ import pickle
 from Service.DataPreprocessingService import *
 from Service.TransformService import *
 
-model_pkl_path = "../Jupyter/technical_debt_model.pkl"
-pca_pkl_path = "../Jupyter/pca.pkl"
+model_pkl_path = "./Jupyter/technical_debt_model.pkl"
+pca_pkl_path = "./Jupyter/pca.pkl"
 
 def load_model(path):
     with open(path, 'rb') as file:

--- a/Service/TransformService.py
+++ b/Service/TransformService.py
@@ -2,9 +2,10 @@ def transform_extracted_data(result):
     result['CodeSimilarity'] = get_list_values_from_sub_dict(result['CodeSimilarity'])
     result['ClassCouplingListing'] = get_list_values_from_dict(result['ClassCouplingListing'])
     result['EndOfLifeFramework'] = count_true_statuses(result['EndOfLifeFramework'])
-    result['ExternalAPICalls'] = get_list_values_from_dict(result['ExternalAPICalls'])
+    result['ExternalAPICalls'] = get_list_from_multi_dict(result['ExternalAPICalls'])
     result['CodeLinesPerFile'] = get_from_list(result['CodeLinesPerFile'])
     result['CommentLinesPerFile'] = get_from_list(result['CommentLinesPerFile'])
+    result.pop('MismatchedNamespace')
     return result
 
 def get_from_list(data):
@@ -19,11 +20,12 @@ def count_true_statuses(data):
                 count += 1
     return count
 
-
 def get_list_values_from_dict(dict):
     return list(dict.values())
-
 
 def get_list_values_from_sub_dict(dict):
     all_values = [value for sub_dict in dict.values() for value in sub_dict.values()]
     return list(dict.fromkeys(all_values))
+
+def get_list_from_multi_dict(dict):
+    return [value['Usage'] for value in dict.values()]


### PR DESCRIPTION
# Updated the transform method

new method to handle the data for external providers 
ignores the mismatched namespace in the transform method since the system is not using it

![image](https://github.com/stefaniatomuta/BPR-MAL/assets/41446902/b8e68a0f-774f-456a-8a0d-691d74302cd3)
